### PR TITLE
Fix CHANGELOG order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2021-03-26
+
+Fixed the `system_error` raised on the `close` of the device(see [ref](https://github.com/robotology/yarp-device-xsensmt/issues/27))
+
 ## [0.1.0] - 2020-01-21
 
 First release of `xsensmt-yarp-driver`, compatible with YARP 3.3 and based on MT Software Suite 4.8.2 . 
 
-## [0.1.1] - 2021-03-26
-
-Fixed the `system_error` raised on the `close` of the device(see [ref](https://github.com/robotology/yarp-device-xsensmt/issues/27))


### PR DESCRIPTION
The latest release should be on top, see https://keepachangelog.com/en/1.0.0/ .