### PR TITLE
Update XsensMT.h

### DIFF
--- a/xsensmt/XsensMT.h
+++ b/xsensmt/XsensMT.h
@@ -11,10 +11,10 @@
 #include "deviceclass.h"
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/GenericSensorInterfaces.h>
+#include <yarp/dev/IGenericSensor.h>
 #include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
 #include <yarp/os/Stamp.h>
-#include <yarp/dev/PreciselyTimed.h>
+#include <yarp/dev/IPreciselyTimed.h>
 
 #include <cstdint>
 #include <atomic>


### PR DESCRIPTION
Fixed deprecated headers.
See also:
- https://github.com/robotology/icub-main/pull/841

cc @davidetome