### PR TITLE
Add the possibility to set a different frequency for each sensor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Update Extern library to the latest XDA (2022.0.0) (https://github.com/robotology/yarp-device-xsensmt/pull/38).
 
+Add the possibility to set a different frequency for each sensor exposed by the device (https://github.com/robotology/yarp-device-xsensmt/pull/40).
+
 ## [0.2.2] - 2022-11-17
 
 Fix compatibility with YARP 3.8 (https://github.com/robotology/yarp-device-xsensmt/pull/36).

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ as much as possible the behaviour of the [`xsensmtx` device](https://github.com/
 
 ## Installation
 
-##### Dependencies
+### Dependencies
 - [YARP](https://github.com/robotology/yarp)
 
-##### Step-by-step installation
+### Step-by-step installation
 * Install YARP on your platform, following the instructions on [YARP documentation](http://www.yarp.it/install.html). 
 * Compile the code in this repository using [CMake](https://cmake.org/) and your preferred compiler. See [YARP documentation on how to compile a CMake project](http://www.yarp.it/using_cmake.html).
 * Install the project. You can specify the installation directory prefix using the [`CMAKE_INSTALL_PREFIX`](https://cmake.org/cmake/help/v3.0/variable/CMAKE_INSTALL_PREFIX.html) CMake option.
@@ -27,7 +27,42 @@ Yes, this is a YARP plugin
 ~~~
 If this is not the case, there could be some problems in finding the plugin. In that case, just move yourself to the `${CMAKE_INSTALL_PREFIX}/share/yarp` directory and launch the device from there.
 
-##### Device use 
+## Device use 
+
+### Via `multipleanalogsensorsserver`
+To launch the `xsensmt` device, you can connect the Xsens IMU (for example the MTI-300) to your
+Linux computer, create an `xml` file named `xsens_imu.xml` containing
+```xml
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+<robot name="realsense" build=0 portprefix="/xsens_imu">
+
+  <device type="xsensmt" name="xsens_imu">
+    <param name="xsensmt_period">0.01</param>
+    <param name="xsensmt_euler_period">0.005</param>
+    <param name="xsensmt_gyro_period">0.005</param>
+    <param name="xsensmt_acc_period">0.005</param>
+    <param name="xsensmt_mag_period">0.01</param>
+  </device>
+
+  <device type="multipleanalogsensorsserver" name="xsens_imu_wrapper">
+    <param name="period">5</param>
+    <param name="name">/xsens_imu</param>
+
+    <action phase="startup" level="5" type="attach">
+      <paramlist name="networks">
+        <elem name="imu">xsens_imu</elem>
+      </paramlist>
+    </action>
+    <action phase="shutdown" level="5" type="detach"/>
+  </device>
+
+</robot>
+```
+Run the `yarpserver`, then on a terminal launch the device: `yarprobotinterface --config xsens_imu.xml`
+
+### Via `inertial` network device (Deprecated)
+
 To launch the `xsensmt` device, you can connect the Xsens IMU (for example the MTI-300) to your Linux computer and the default configuration parameters should be sufficient to work fine.
 To do so, launch the yarpserver, then on a terminal launch the device:
 ~~~
@@ -37,4 +72,23 @@ This should open a YARP port `/inertial` , that you can read from the command li
 ~~~
 yarp read ... /inertial
 ~~~
-If you need to change the configuration parameters, check the device documentation in https://github.com/loc2/xsensmt-yarp-driver/blob/master/xsensmt/XsensMT.h#L41 .
+
+### Parameters
+
+The following table contains the parameters currently supported by the device
+
+| Parameter name | Type    | Units | Default Value | Required  | Description   | Notes |
+|:--------------:|:-------:|:-----:|:-------------:|:--------: |:-------------:|:-----:|
+| `serial`         | string  |       | /dev/ttyUSB0  | No        | File name of the serial device to which to connect.  | |
+| `baud`           | int     |       | 115200        | No        | Baud rate used by the serial communication." | |
+| `timeout`        | double  |seconds| 0.1           | No        | If the device is not receiving any sensor measure for timeout seconds, it will start reporting an error. | - |
+| `sensor_name`    | string  |       | sensor_imu_xsensmt       | No        | Name of the inertial sensor device. | |
+| frame_name     | string  |       | set same as `sensor_name` | No    | Sensor frame in which the measurements are expressed. |
+| `xsensmt_period`     | double  |    seconds   | 0.01  | No    | Period of querying the Xsens MT* device. This parameter is used for each sensor for which the user does not specify the specific associated period.   | The frequency of publishing the information is determined by the device that attaches this one |
+| `xsensmt_acc_period`     | double  |    seconds   | `xsensmt_period`  | No    | Period of querying the Accelerometer Xsens MT* device | The frequency of publishing the information is determined by the device that attaches this one |
+| `xsensmt_gyro_period`     | double  |    seconds   | `xsensmt_period`  | No   | Period of querying the Gyroscope Xsens MT* device | The frequency of publishing the information is determined by the device that attaches this one |
+| `xsensmt_mag_period`     | double  |    seconds   | `xsensmt_period`  | No   | Period of querying the Magnetometer Xsens MT* device | The frequency of publishing the information is determined by the device that attaches this one |
+| `xsensmt_euler_period`     | double  |    seconds   | `xsensmt_period`  | No   | Period of querying the Euler Xsens MT* device | The frequency of publishing the information is determined by the device that attaches this one |
+| `xsensmt_position_period`     | double  |    seconds   | `xsensmt_period`  | No   | Period of querying the Position Xsens MT* device | The frequency of publishing the information is determined by the device that attaches this one |
+| `xsensmt_linear_velocity_period`     | double  |    seconds   | `xsensmt_period`  | No   | Period of querying the linear velocity Xsens MT* device | The frequency of publishing the information is determined by the device that attaches this one |
+

--- a/xsensmt/XsensMT.h
+++ b/xsensmt/XsensMT.h
@@ -18,6 +18,7 @@
 #include <yarp/dev/MultipleAnalogSensorsInterfaces.h>
 #include <yarp/os/Stamp.h>
 #include <yarp/dev/IPreciselyTimed.h>
+#include <yarp/sig/Vector.h>
 
 #include <cstdint>
 #include <atomic>
@@ -25,6 +26,7 @@
 #include <string>
 #include <thread>
 #include <list>
+#include <functional>
 
 namespace yarp
 {
@@ -34,6 +36,44 @@ namespace dev
 }
 }
 
+class TimedData
+{
+    yarp::sig::Vector m_data;
+    yarp::os::Stamp m_timestamp;
+    bool m_dataArrived{false};
+    mutable std::mutex m_mutex;
+
+public:
+    TimedData();
+
+    void setData(const XsEuler& euler,
+                 const yarp::os::Stamp& time,
+                 std::function<double(const double&)> conversion = [](const double& element){return element;});
+
+    void setData(const XsVector& vector,
+                 const yarp::os::Stamp& time,
+                 std::function<double(const double&)> conversion = [](const double& element){return element;});
+
+
+    bool getData(yarp::sig::Vector& data, double& timestamp) const;
+};
+
+struct SensorDataCollection
+{
+    TimedData euler;
+    TimedData acc;
+    TimedData gyro;
+    TimedData mag;
+
+    void updateLastReadStamp(const double& t);
+    double getLastReadStampAsDouble();
+    yarp::os::Stamp getLastReadStamp();
+
+private:
+    mutable std::mutex m_lastReadStampMutex;
+    yarp::os::Stamp m_lastReadStamp;
+};
+
 /**
  * \section CallbackHandler Controls reading data from XsDevice object
  * \brief This class is copied from the Public Xsens device API example MTi receive data.
@@ -41,50 +81,12 @@ namespace dev
 class CallbackHandler : public XsCallback
 {
 public:
-    CallbackHandler(size_t maxBufferSize = 5)
-        : m_maxNumberOfPacketsInBuffer(maxBufferSize)
-        , m_numberOfPacketsInBuffer(0)
-    {
-    }
 
-    virtual ~CallbackHandler() throw()
-    {
-    }
-
-    bool packetAvailable() const
-    {
-        xsens::Lock locky(&m_mutex);
-        return m_numberOfPacketsInBuffer > 0;
-    }
-
-    XsDataPacket getNextPacket()
-    {
-        assert(packetAvailable());
-        xsens::Lock locky(&m_mutex);
-        XsDataPacket oldestPacket(m_packetBuffer.front());
-        m_packetBuffer.pop_front();
-        --m_numberOfPacketsInBuffer;
-        return oldestPacket;
-    }
+    virtual ~CallbackHandler() throw() = default;
+    SensorDataCollection packetBuffer;
 
 protected:
-    void onLiveDataAvailable(XsDevice*, const XsDataPacket* packet) override
-    {
-        xsens::Lock locky(&m_mutex);
-        assert(packet != 0);
-        while (m_numberOfPacketsInBuffer >= m_maxNumberOfPacketsInBuffer)
-            (void)getNextPacket();
-
-        m_packetBuffer.push_back(*packet);
-        ++m_numberOfPacketsInBuffer;
-        assert(m_numberOfPacketsInBuffer <= m_maxNumberOfPacketsInBuffer);
-    }
-private:
-    mutable xsens::Mutex m_mutex;
-
-    size_t m_maxNumberOfPacketsInBuffer;
-    size_t m_numberOfPacketsInBuffer;
-    std::list<XsDataPacket> m_packetBuffer;
+    void onLiveDataAvailable(XsDevice*, const XsDataPacket* packet) override;
 };
 
 
@@ -103,7 +105,13 @@ private:
 * | timeout        | double  |seconds| 0.1           | No        | If the device is not receiving any sensor measure for timeout seconds, it will start reporting an error. | - |
 * | sensor_name    | string  |       | sensor_imu_xsensmt       | No        | Name of the inertial sensor device. | |
 * | frame_name     | string  |       | set same as `sensor_name` | No    | Sensor frame in which the measurements are expressed. |
-* | xsensmt_period     | double  |    seconds   | 0.01  | No    | Period of querying the Xsens MT* device | The frequency of publishing the information is determined by the device that attaches this one |
+* | xsensmt_period     | double  |    seconds   | 0.01  | No    | Period of querying the Xsens MT* device. This parameter is used for each sensor for which the user does not specify the specific associated period.   | The frequency of publishing the information is determined by the device that attaches this one |
+* | xsensmt_acc_period     | double  |    seconds   | xsensmt_period  | No    | Period of querying the Accelerometer Xsens MT* device | The frequency of publishing the information is determined by the device that attaches this one |
+* | xsensmt_gyro_period     | double  |    seconds   | xsensmt_period  | No   | Period of querying the Gyroscope Xsens MT* device | The frequency of publishing the information is determined by the device that attaches this one |
+* | xsensmt_mag_period     | double  |    seconds   | xsensmt_period  | No   | Period of querying the Magnetometer Xsens MT* device | The frequency of publishing the information is determined by the device that attaches this one |
+* | xsensmt_euler_period     | double  |    seconds   | xsensmt_period  | No   | Period of querying the Euler Xsens MT* device | The frequency of publishing the information is determined by the device that attaches this one |
+* | xsensmt_position_period     | double  |    seconds   | xsensmt_period  | No   | Period of querying the Position Xsens MT* device | The frequency of publishing the information is determined by the device that attaches this one |
+* | xsensmt_linear_velocity_period     | double  |    seconds   | xsensmt_period  | No   | Period of querying the linear velocity Xsens MT* device | The frequency of publishing the information is determined by the device that attaches this one |
 **/
 class yarp::dev::XsensMT : public yarp::dev::IGenericSensor,
                            public yarp::dev::IPreciselyTimed,
@@ -123,35 +131,35 @@ public:
      * @param[out] out a vector containing the sensor's last readings.
      * @return true/false success/failure
      */
-    virtual bool read(yarp::sig::Vector &out);
-    
+    virtual bool read(yarp::sig::Vector &out) override;
+
     /**
      * Get the number of channels of the sensor.
      * @param[out] nc pointer to storage, return value
      * @return true/false success/failure
      */
-    virtual bool getChannels(int *nc);
-    
+    virtual bool getChannels(int *nc) override;
+
     /**
      * Open the device and set up parameters/communication
      * @param[in] config searchable object with desired configuration parameters
      * @return true/false success/failure
      */
-    virtual bool open(yarp::os::Searchable &config);
-    
+    virtual bool open(yarp::os::Searchable &config) override;
+
     /**
      * Calibrate the sensor, single channel.
      * @param[in] ch channel number
      * @param[in] v reset value
      * @return true/false success/failure
      */
-    virtual bool calibrate(int ch, double v);
-    
+    virtual bool calibrate(int ch, double v) override;
+
     /**
      * Close the device
      * @return true/false success/failure
-     */ 
-    virtual bool close();
+     */
+    virtual bool close() override;
 
     /* IThreeAxisGyroscopes methods */
     /**
@@ -159,9 +167,9 @@ public:
      * @return 1
      */
     virtual size_t getNrOfThreeAxisGyroscopes() const override;
-    
+
     /**
-     * Get the status of three axis gyroscope 
+     * Get the status of three axis gyroscope
      * @param[in] sens_index sensor index (must be 0 in the case xsensmt)
      * @return MAS_OK/MAS_ERROR if status ok/failure
      */
@@ -180,12 +188,12 @@ public:
      * @param[in] sens_index sensor index (must be 0 in the case xsensmt)
      * @param[out] frameName name of the sensor frame
      * @return true/false success/failure
-     */  
+     */
     virtual bool getThreeAxisGyroscopeFrameName(size_t sens_index, std::string &frameName) const override;
-    
-    
+
+
     /**
-     * Get three axis gyroscope measurements 
+     * Get three axis gyroscope measurements
      * @param[in] sens_index sensor index (must be 0 in the case xsensmt)
      * @param[out] out 3D angular velocity measurement in deg/s
      * @param[out] timestamp timestamp of measurement
@@ -199,14 +207,14 @@ public:
      * @return 1
      */
     virtual size_t getNrOfThreeAxisLinearAccelerometers() const override;
-    
+
     /**
      * Get the status of three axis linear accelerometer
      * @param[in] sens_index sensor index (must be 0 in the case xsensmt)
      * @return MAS_OK/MAS_ERROR if status ok/failure
      */
     virtual yarp::dev::MAS_status getThreeAxisLinearAccelerometerStatus(size_t sens_index) const override;
-    
+
     /**
      * Get the name of three axis linear accelerometer
      * @param[in] sens_index sensor index (must be 0 in the case xsensmt)
@@ -214,17 +222,17 @@ public:
      * @return true/false success/failure
      */
     virtual bool getThreeAxisLinearAccelerometerName(size_t sens_index, std::string &name) const override;
-    
+
     /**
      * Get the name of the frame in which three axis linear accelerometer measurements are expressed
      * @param[in] sens_index sensor index (must be 0 in the case xsensmt)
      * @param[out] frameName name of the sensor frame
      * @return true/false success/failure
-     */  
+     */
     virtual bool getThreeAxisLinearAccelerometerFrameName(size_t sens_index, std::string &frameName) const override;
-    
+
     /**
-     * Get three axis linear accelerometer measurements 
+     * Get three axis linear accelerometer measurements
      * @param[in] sens_index sensor index (must be 0 in the case xsensmt)
      * @param[out] out 3D linear acceleration measurement in m/s^2
      * @param[out] timestamp timestamp of measurement
@@ -238,14 +246,14 @@ public:
      * @return 1
      */
     virtual size_t getNrOfThreeAxisMagnetometers() const override;
-    
+
     /**
-     * Get the status of three axis magnetometer 
+     * Get the status of three axis magnetometer
      * @param[in] sens_index sensor index (must be 0 in the case xsensmt)
      * @return MAS_OK/MAS_ERROR if status ok/failure
      */
     virtual yarp::dev::MAS_status getThreeAxisMagnetometerStatus(size_t sens_index) const override;
-    
+
     /**
      * Get the name of three axis magnetometer
      * @param[in] sens_index sensor index (must be 0 in the case xsensmt)
@@ -253,17 +261,17 @@ public:
      * @return true/false success/failure
      */
     virtual bool getThreeAxisMagnetometerName(size_t sens_index, std::string &name) const override;
-    
+
     /**
      * Get the name of the frame in which three axis magnetometer measurements are expressed
      * @param[in] sens_index sensor index (must be 0 in the case xsensmt)
      * @param[out] frameName name of the sensor frame
      * @return true/false success/failure
-     */  
+     */
     virtual bool getThreeAxisMagnetometerFrameName(size_t sens_index, std::string &frameName) const override;
-    
+
     /**
-     * Get three axis magnetometer measurements 
+     * Get three axis magnetometer measurements
      * @param[in] sens_index sensor index (must be 0 in the case xsensmt)
      * @param[out] out 3D magnetometer measurement
      * @param[out] timestamp timestamp of measurement
@@ -277,14 +285,14 @@ public:
      * @return 1
      */
     virtual size_t getNrOfOrientationSensors() const override;
-    
+
     /**
      * Get the status of orientation sensor
      * @param[in] sens_index sensor index (must be 0 in the case xsensmt)
      * @return MAS_OK/MAS_ERROR if status ok/failure
      */
     virtual yarp::dev::MAS_status getOrientationSensorStatus(size_t sens_index) const override;
-    
+
     /**
      * Get the name of orientation sensor
      * @param[in] sens_index sensor index (must be 0 in the case xsensmt)
@@ -292,17 +300,17 @@ public:
      * @return true/false success/failure
      */
     virtual bool getOrientationSensorName(size_t sens_index, std::string &name) const override;
-    
+
     /**
      * Get the name of the frame in which orientation sensor measurements are expressed
      * @param[in] sens_index sensor index (must be 0 in the case xsensmt)
      * @param[out] frameName name of the sensor frame
      * @return true/false success/failure
-     */  
+     */
     virtual bool getOrientationSensorFrameName(size_t sens_index, std::string &frameName) const override;
-    
+
     /**
-     * Get orientation sensor measurements 
+     * Get orientation sensor measurements
      * @param[in] sens_index sensor index (must be 0 in the case xsensmt)
      * @param[out] out RPY Euler angles in deg
      * @param[out] timestamp timestamp of measurement
@@ -310,46 +318,36 @@ public:
      */
     virtual bool getOrientationSensorMeasureAsRollPitchYaw(size_t sens_index, yarp::sig::Vector& rpy, double& timestamp) const override;
 
-    
-    // Function executed by m_sensorThread
-    void sensorReadLoop();
-
-    virtual yarp::os::Stamp getLastInputStamp();
-
-    // Thread running the sensorReadLoop method
-    std::thread m_sensorThread;
+    virtual yarp::os::Stamp getLastInputStamp() override;
 
 private:
     yarp::dev::MAS_status genericGetStatus(size_t sens_index) const;
     bool genericGetSensorName(size_t sens_index, std::string &name) const;
     bool genericGetFrameName(size_t sens_index, std::string &frameName) const;
-    
+
     std::string m_sensorName;
     std::string m_frameName;
-    double m_outputPeriod;
-    double m_outputFrequency;
-    
-    int m_nchannels{12};
+
+    struct SensorFrequencies
+    {
+        double acc{-1};
+        double gyro{-1};
+        double mag{-1};
+        double euler{-1};
+        double position{-1};
+        double linearVelocity{-1};
+    };
+
+    SensorFrequencies m_frequencies;
+
+    const int m_nchannels{12};
     double m_timeoutInSecond{0.1};
-
-    // True if the close method has been called at least once
-    std::atomic<bool> m_isDeviceClosing{false};
-
-    // True if a valid sensor measurement has been received in the last m_sensorTimeout seconds
-    bool m_isSensorMeasurementAvailable{false};
 
     // Interface exposed by the Xsens MT Software suite
     XsControl* m_xsensControl{nullptr};
     XsDevice* m_xsensDevice{nullptr};
     XsPortInfo m_portInfo;
     CallbackHandler m_callback;
-
-    yarp::os::Stamp  m_lastReadStamp;
-
-    // Mutex protecting m_sensorBuffer, m_lastStamp
-    mutable std::mutex m_bufferMutex;
-    yarp::sig::Vector m_sensorBuffer;
-    yarp::os::Stamp  m_lastStamp;
 };
 
 


### PR DESCRIPTION
Thanks to this PR it will be possible to set different frequencies for each sensor exposed in the device. To do that I:
- removed the polling thread and used the callback provided by xsens to get the data
- Add optional parameters to specifically set the period of each sensor exposed by the IMU. If the parameter is not passed the  `xsensmt_period` is used. This means that this implementation is retro compatible with the already existing configuration files
- I updated the readme

cc @traversaro @HosameldinMohamed 