### PR TITLE
added an option to reset roll, pitch and yaw when the device starts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ Makefile
 # Clangd files
 **/.cache
 **/compile_commands.json
+
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Added an option to reset the orientation of the IMU (https://github.com/robotology/yarp-device-xsensmt/pull/43)
+
 Update Extern library to the latest XDA (2022.0.0) (https://github.com/robotology/yarp-device-xsensmt/pull/38).
 
 Add the possibility to set a different frequency for each sensor exposed by the device (https://github.com/robotology/yarp-device-xsensmt/pull/40).

--- a/README.md
+++ b/README.md
@@ -91,4 +91,4 @@ The following table contains the parameters currently supported by the device
 | `xsensmt_euler_period`     | double  |    seconds   | `xsensmt_period`  | No   | Period of querying the Euler Xsens MT* device | The frequency of publishing the information is determined by the device that attaches this one |
 | `xsensmt_position_period`     | double  |    seconds   | `xsensmt_period`  | No   | Period of querying the Position Xsens MT* device | The frequency of publishing the information is determined by the device that attaches this one |
 | `xsensmt_linear_velocity_period`     | double  |    seconds   | `xsensmt_period`  | No   | Period of querying the linear velocity Xsens MT* device | The frequency of publishing the information is determined by the device that attaches this one |
-
+| `resetSensorOrientation` | bool|   | `false`  | No        | Option to be set to true if the orientation has to be reset as the device starts.  | |

--- a/xsensmt/XsensMT.cpp
+++ b/xsensmt/XsensMT.cpp
@@ -364,6 +364,18 @@ bool XsensMT::open(yarp::os::Searchable &config)
         return false;
     }
 
+    if(config.check("reset"))
+    {
+        bool okReset = m_xsensDevice->resetOrientation(XRM_Alignment);
+        if(okReset)
+        {
+            yDebug() << "the reset was successful";
+        } else 
+        {
+            yWarning() << "the reset failed";
+        }
+    }
+
     // Create and attach callback handler to device
     m_xsensDevice->addCallbackHandler(&m_callback);
 

--- a/xsensmt/XsensMT.cpp
+++ b/xsensmt/XsensMT.cpp
@@ -364,15 +364,19 @@ bool XsensMT::open(yarp::os::Searchable &config)
         return false;
     }
 
+    // reset the orientation if the 'reset' parameter is true
     if(config.check("reset"))
     {
-        bool okReset = m_xsensDevice->resetOrientation(XRM_Alignment);
-        if(okReset)
+        if(config.find("reset").asBool())
         {
-            yDebug() << "the reset was successful";
-        } else 
-        {
-            yWarning() << "the reset failed";
+            bool okReset = m_xsensDevice->resetOrientation(XRM_Alignment);
+            if(okReset)
+            {
+                yInfo() << "xsensmt: resetting the orientation";
+            } else 
+            {
+                yWarning() << "xsensmt: the reset of the orientation failed";
+            }
         }
     }
 

--- a/xsensmt/XsensMT.cpp
+++ b/xsensmt/XsensMT.cpp
@@ -365,9 +365,9 @@ bool XsensMT::open(yarp::os::Searchable &config)
     }
 
     // reset the orientation if the 'reset' parameter is true
-    if(config.check("reset"))
+    if(config.check("resetSensorOrientation"))
     {
-        if(config.find("reset").asBool())
+        if(config.find("resetSensorOrientation").asBool())
         {
             bool okReset = m_xsensDevice->resetOrientation(XRM_Alignment);
             if(okReset)

--- a/xsensmt/XsensMT.h
+++ b/xsensmt/XsensMT.h
@@ -112,7 +112,7 @@ protected:
 * | xsensmt_euler_period     | double  |    seconds   | xsensmt_period  | No   | Period of querying the Euler Xsens MT* device | The frequency of publishing the information is determined by the device that attaches this one |
 * | xsensmt_position_period     | double  |    seconds   | xsensmt_period  | No   | Period of querying the Position Xsens MT* device | The frequency of publishing the information is determined by the device that attaches this one |
 * | xsensmt_linear_velocity_period     | double  |    seconds   | xsensmt_period  | No   | Period of querying the linear velocity Xsens MT* device | The frequency of publishing the information is determined by the device that attaches this one |
-* | reset          | bool   |        | False         | No        | Option to be set to true if the orientation has to be reset as the device starts.  | |
+* | resetSensorOrientation | bool|   | False  | No        | Option to be set to true if the orientation has to be reset as the device starts.  | |
 **/
 class yarp::dev::XsensMT : public yarp::dev::IGenericSensor,
                            public yarp::dev::IPreciselyTimed,

--- a/xsensmt/XsensMT.h
+++ b/xsensmt/XsensMT.h
@@ -112,6 +112,7 @@ protected:
 * | xsensmt_euler_period     | double  |    seconds   | xsensmt_period  | No   | Period of querying the Euler Xsens MT* device | The frequency of publishing the information is determined by the device that attaches this one |
 * | xsensmt_position_period     | double  |    seconds   | xsensmt_period  | No   | Period of querying the Position Xsens MT* device | The frequency of publishing the information is determined by the device that attaches this one |
 * | xsensmt_linear_velocity_period     | double  |    seconds   | xsensmt_period  | No   | Period of querying the linear velocity Xsens MT* device | The frequency of publishing the information is determined by the device that attaches this one |
+* | reset          | bool   |        | False         | No        | Option to be set to true if the orientation has to be reset as the device starts.  | |
 **/
 class yarp::dev::XsensMT : public yarp::dev::IGenericSensor,
                            public yarp::dev::IPreciselyTimed,


### PR DESCRIPTION
I open this PR in order to add an option to reset the orientation of the IMU when the device starts; to do it, it is just necessary to add the parameter `--reset` in the `yarprobotinterface`.

CC @HosameldinMohamed @traversaro 