### PR TITLE
Bump to 0.3.0, fix Windows compilation and change license to BSD-3-Clause

### DIFF
--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -24,23 +24,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: mamba-org/setup-micromamba@v1
       with:
-        mamba-version: "*"
-        channels: conda-forge,robotology
-        channel-priority: true
+        environment-file: ci_env.yml
 
     - uses: rlespinasse/github-slug-action@v3.x
-
-    - name: Dependencies
-      shell: bash -l {0}
-      run: |
-        # Workaround for https://github.com/conda-incubator/setup-miniconda/issues/186
-        conda config --remove channels defaults
-        # Compilation related dependencies
-        mamba install cmake compilers make ninja pkg-config
-        # Actual dependencies
-        mamba install -c conda-forge -c robotology yarp
 
     - name: Configure [Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2023-10-17
+
 Update Extern library to the latest XDA (2022.0.0) (https://github.com/robotology/yarp-device-xsensmt/pull/38).
 
 Add the possibility to set a different frequency for each sensor exposed by the device (https://github.com/robotology/yarp-device-xsensmt/pull/40).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
-# Copyright (C) 2017-2020 Fondazione Istituto Italiano di Tecnologia
-# Authors: Silvio Traversaro <silvio.traversaro@iit.it>
-# CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LICENSE
+# SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
 
 cmake_minimum_required(VERSION 3.5)
 project(yarp-device-xsensmt)

--- a/LICENSE
+++ b/LICENSE
@@ -1,165 +1,29 @@
-                   GNU LESSER GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
+BSD 3-Clause License
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
+Copyright (c) Fondazione Istituto Italiano di Tecnologia (IIT), 
+              Xsens Technologies B.V. or subsidiaries worldwide.
 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-  This version of the GNU Lesser General Public License incorporates
-the terms and conditions of version 3 of the GNU General Public
-License, supplemented by the additional permissions listed below.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-  0. Additional Definitions.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-  As used herein, "this License" refers to version 3 of the GNU Lesser
-General Public License, and the "GNU GPL" refers to version 3 of the GNU
-General Public License.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
-  "The Library" refers to a covered work governed by this License,
-other than an Application or a Combined Work as defined below.
-
-  An "Application" is any work that makes use of an interface provided
-by the Library, but which is not otherwise based on the Library.
-Defining a subclass of a class defined by the Library is deemed a mode
-of using an interface provided by the Library.
-
-  A "Combined Work" is a work produced by combining or linking an
-Application with the Library.  The particular version of the Library
-with which the Combined Work was made is also called the "Linked
-Version".
-
-  The "Minimal Corresponding Source" for a Combined Work means the
-Corresponding Source for the Combined Work, excluding any source code
-for portions of the Combined Work that, considered in isolation, are
-based on the Application, and not on the Linked Version.
-
-  The "Corresponding Application Code" for a Combined Work means the
-object code and/or source code for the Application, including any data
-and utility programs needed for reproducing the Combined Work from the
-Application, but excluding the System Libraries of the Combined Work.
-
-  1. Exception to Section 3 of the GNU GPL.
-
-  You may convey a covered work under sections 3 and 4 of this License
-without being bound by section 3 of the GNU GPL.
-
-  2. Conveying Modified Versions.
-
-  If you modify a copy of the Library, and, in your modifications, a
-facility refers to a function or data to be supplied by an Application
-that uses the facility (other than as an argument passed when the
-facility is invoked), then you may convey a copy of the modified
-version:
-
-   a) under this License, provided that you make a good faith effort to
-   ensure that, in the event an Application does not supply the
-   function or data, the facility still operates, and performs
-   whatever part of its purpose remains meaningful, or
-
-   b) under the GNU GPL, with none of the additional permissions of
-   this License applicable to that copy.
-
-  3. Object Code Incorporating Material from Library Header Files.
-
-  The object code form of an Application may incorporate material from
-a header file that is part of the Library.  You may convey such object
-code under terms of your choice, provided that, if the incorporated
-material is not limited to numerical parameters, data structure
-layouts and accessors, or small macros, inline functions and templates
-(ten or fewer lines in length), you do both of the following:
-
-   a) Give prominent notice with each copy of the object code that the
-   Library is used in it and that the Library and its use are
-   covered by this License.
-
-   b) Accompany the object code with a copy of the GNU GPL and this license
-   document.
-
-  4. Combined Works.
-
-  You may convey a Combined Work under terms of your choice that,
-taken together, effectively do not restrict modification of the
-portions of the Library contained in the Combined Work and reverse
-engineering for debugging such modifications, if you also do each of
-the following:
-
-   a) Give prominent notice with each copy of the Combined Work that
-   the Library is used in it and that the Library and its use are
-   covered by this License.
-
-   b) Accompany the Combined Work with a copy of the GNU GPL and this license
-   document.
-
-   c) For a Combined Work that displays copyright notices during
-   execution, include the copyright notice for the Library among
-   these notices, as well as a reference directing the user to the
-   copies of the GNU GPL and this license document.
-
-   d) Do one of the following:
-
-       0) Convey the Minimal Corresponding Source under the terms of this
-       License, and the Corresponding Application Code in a form
-       suitable for, and under terms that permit, the user to
-       recombine or relink the Application with a modified version of
-       the Linked Version to produce a modified Combined Work, in the
-       manner specified by section 6 of the GNU GPL for conveying
-       Corresponding Source.
-
-       1) Use a suitable shared library mechanism for linking with the
-       Library.  A suitable mechanism is one that (a) uses at run time
-       a copy of the Library already present on the user's computer
-       system, and (b) will operate properly with a modified version
-       of the Library that is interface-compatible with the Linked
-       Version.
-
-   e) Provide Installation Information, but only if you would otherwise
-   be required to provide such information under section 6 of the
-   GNU GPL, and only to the extent that such information is
-   necessary to install and execute a modified version of the
-   Combined Work produced by recombining or relinking the
-   Application with a modified version of the Linked Version. (If
-   you use option 4d0, the Installation Information must accompany
-   the Minimal Corresponding Source and Corresponding Application
-   Code. If you use option 4d1, you must provide the Installation
-   Information in the manner specified by section 6 of the GNU GPL
-   for conveying Corresponding Source.)
-
-  5. Combined Libraries.
-
-  You may place library facilities that are a work based on the
-Library side by side in a single library together with other library
-facilities that are not Applications and are not covered by this
-License, and convey such a combined library under terms of your
-choice, if you do both of the following:
-
-   a) Accompany the combined library with a copy of the same work based
-   on the Library, uncombined with any other library facilities,
-   conveyed under the terms of this License.
-
-   b) Give prominent notice with the combined library that part of it
-   is a work based on the Library, and explaining where to find the
-   accompanying uncombined form of the same work.
-
-  6. Revised Versions of the GNU Lesser General Public License.
-
-  The Free Software Foundation may publish revised and/or new versions
-of the GNU Lesser General Public License from time to time. Such new
-versions will be similar in spirit to the present version, but may
-differ in detail to address new problems or concerns.
-
-  Each version is given a distinguishing version number. If the
-Library as you received it specifies that a certain numbered version
-of the GNU Lesser General Public License "or any later version"
-applies to it, you have the option of following the terms and
-conditions either of that published version or of any later version
-published by the Free Software Foundation. If the Library as you
-received it does not specify a version number of the GNU Lesser
-General Public License, you may choose any version of the GNU Lesser
-General Public License ever published by the Free Software Foundation.
-
-  If the Library as you received it specifies that a proxy can decide
-whether future versions of the GNU Lesser General Public License shall
-apply, that proxy's public statement of acceptance of any version is
-permanent authorization for you to choose that version for the
-Library.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/ci_env.yml
+++ b/ci_env.yml
@@ -1,0 +1,10 @@
+name: yarpdevicexsensmtdev
+channels:
+  - conda-forge
+dependencies:
+  - cmake 
+  - compilers
+  - make 
+  - ninja
+  - pkg-config 
+  - yarp

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -9,6 +9,15 @@
 
 find_package (Threads)
 
+# To force the inclusion of a file, the option are different:
+# -include for gcc/clang
+# /FI for msvc
+if (MSVC)
+  set(XSENS_FORCE_INCLUSION_OPTION "/FI")
+else()
+  set(XSENS_FORCE_INCLUSION_OPTION "-include")
+endif()
+
 # Globbing should be avoided in general, but this is a library that we use directly as provided by Xsens 
 file(GLOB xstypes_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/xspublic/xstypes/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/xspublic/xstypes/*.c)
 # See EXCLUDE argument in xstypes' Makefile
@@ -23,7 +32,7 @@ file(GLOB xscommon_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/xspublic/xscommon/*.cpp ${CM
 add_library(xscommon STATIC ${xscommon_SRCS})
 target_include_directories(xscommon PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/xspublic)
 target_include_directories(xscommon PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/xspublic/xscommon)
-target_compile_options(xscommon PRIVATE "SHELL:-include xscommon_config.h" "SHELL:-include xstypes/xsens_compat.h")
+target_compile_options(xscommon PRIVATE "SHELL:${XSENS_FORCE_INCLUSION_OPTION} xscommon_config.h" "SHELL:${XSENS_FORCE_INCLUSION_OPTION} xstypes/xsens_compat.h")
 target_link_libraries(xscommon PUBLIC xstypes)
 
 
@@ -31,9 +40,20 @@ file(GLOB xscontroller_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/xspublic/xscontroller/*.
 add_library(xscontroller STATIC ${xscontroller_SRCS})
 target_include_directories(xscontroller PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/xspublic)
 target_include_directories(xscontroller PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/xspublic/xscontroller)
-target_compile_options(xscontroller PRIVATE "SHELL:-include xscontrollerconfig.h")
+target_compile_options(xscontroller PRIVATE "SHELL:${XSENS_FORCE_INCLUSION_OPTION} xscontrollerconfig.h")
 target_compile_definitions(xscontroller PRIVATE -DHAVE_JOURNALLER)
 target_link_libraries(xscontroller PUBLIC xstypes xscommon)
+
+# Windows system libraries to link
+if (WIN32)
+  target_link_libraries(xscontroller PRIVATE Setupapi)
+endif()
+
+# XDA_STATIC_LIB needs to be defined only if the library is static
+get_target_property(xscontroller_target_type xscontroller TYPE)
+if (xscontroller_target_type STREQUAL "STATIC_LIBRARY")
+  target_compile_definitions(xscontroller PUBLIC XDA_STATIC_LIB)
+endif()
 
 
 add_library(xsens_mt_software_suite INTERFACE)

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -1,6 +1,5 @@
-# Copyright (C) 2017-2023 Fondazione Istituto Italiano di Tecnologia
-# Authors: Silvio Traversaro <silvio.traversaro@iit.it>
-# CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LICENSE
+# SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
 
 # The code contained in this directory is imported directly from the src_cpp example
 # in the MT Software Suite, version 2022.0.0, available from https://www.movella.com/support/software-documentation/

--- a/extern/xspublic/xscontroller/dummy.cpp
+++ b/extern/xspublic/xscontroller/dummy.cpp
@@ -31,8 +31,10 @@
 //  
 
 // This exists just so the library isn't empty for the VS build
-#ifdef _WIN32
-    #include <xscontroller.h>
-#endif
+// In the yarp-device-xsensmt library is build via CMake with different structure,
+// we can comment these lines
+//#ifdef _WIN32
+//    #include <xscontroller.h>
+//#endif
 
 const int xsControllerDummy = 0;

--- a/xsensmt/CMakeLists.txt
+++ b/xsensmt/CMakeLists.txt
@@ -1,6 +1,5 @@
-# Copyright (C) 2017  iCub Facility, Istituto Italiano di Tecnologia
-# Authors: Silvio Traversaro <silvio.traversaro@iit.it>
-# CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LICENSE
+# SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
 
 
 yarp_prepare_plugin(xsensmt TYPE yarp::dev::XsensMT

--- a/xsensmt/XsensMT.cpp
+++ b/xsensmt/XsensMT.cpp
@@ -1,8 +1,5 @@
-/*
- * Copyright (C) 2017 iCub Facility,  Istituto Italiano di Tecnologia
- * Authors: Silvio Traversaro
- * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 
 #include <yarp/os/Log.h>

--- a/xsensmt/XsensMT.h
+++ b/xsensmt/XsensMT.h
@@ -1,9 +1,5 @@
-/*
- * Copyright (C) 2017 iCub Facility,  Istituto Italiano di Tecnologia
- * Authors: Silvio Traversaro
- * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- */
-
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef XSENS_MT_YARP_DRIVER
 #define XSENS_MT_YARP_DRIVER


### PR DESCRIPTION
Fix https://github.com/robotology/yarp-device-xsensmt/issues/45 .
Fix https://github.com/robotology/yarp-device-xsensmt/issues/44 .

For some reason the CI is super-slow, but that is another story.