### PR TITLE
Update Windows OS version in CI workflow

### DIFF
--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         build_type: [Release]
-        os: [ubuntu-latest, windows-2019]
+        os: [ubuntu-latest, windows-2022]
       fail-fast: false
 
     steps:

--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -30,8 +30,8 @@ jobs:
 
     - uses: rlespinasse/github-slug-action@v3.x
 
-    - name: Configure [Linux&macOS]
-      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
+    - name: Configure [Linux]
+      if: contains(matrix.os, 'ubuntu')
       shell: bash -l {0}
       run: |
         mkdir -p build
@@ -45,7 +45,7 @@ jobs:
       run: |
         mkdir -p build
         cd build
-        cmake -G"Visual Studio 16 2019" -DBUILD_TESTING:BOOL=ON \
+        cmake -G"Visual Studio 17 2022" -DBUILD_TESTING:BOOL=ON \
               -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
 
     - name: Build


### PR DESCRIPTION
This is because in June 2025 the windows-2019 runners have been deprecated, they will start soon to be dismissed